### PR TITLE
6186/cross compile intel macos

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -14,7 +14,8 @@
 # --dir <dir> sets the name of the build dir, default is "build"
 # --cmake-generator <generator> sets CMAKE_GENERATOR as used by cmake
 # --target-macos-version <version> sets the min os version - only used for macOS builds
-# uses env: BUILDTYPE MAKE_INSTALL MAKE_PACKAGE PACKAGE_TYPE PACKAGE_SUFFIX MAKE_SERVER MAKE_NO_CLIENT MAKE_TEST USE_CCACHE CCACHE_SIZE CCACHE_VARIANT CCACHE_EVICTION_AGE BUILD_DIR CMAKE_GENERATOR TARGET_MACOS_VERSION
+# --target-macos-architecture <architecture> sets the architecture - only used for macOS builds
+# uses env: BUILDTYPE MAKE_INSTALL MAKE_PACKAGE PACKAGE_TYPE PACKAGE_SUFFIX MAKE_SERVER MAKE_NO_CLIENT MAKE_TEST USE_CCACHE CCACHE_SIZE CCACHE_VARIANT CCACHE_EVICTION_AGE BUILD_DIR CMAKE_GENERATOR TARGET_MACOS_VERSION TARGET_MACOS_ARCH
 # (correspond to args: --debug/--release --install --package <package type> --suffix <suffix> --server --test --ccache <ccache_size> --dir <dir>)
 # exitcode: 1 for failure, 3 for invalid arguments
 
@@ -113,6 +114,15 @@ while [[ $# != 0 ]]; do
       TARGET_MACOS_VERSION="$1"
       shift
       ;;
+    '--target-macos-architecture')
+      shift
+      if [[ $# == 0 ]]; then
+        echo "::error file=$0::--target-macos-architecture expects an argument"
+        exit 3
+      fi
+      TARGET_MACOS_ARCH="$1"
+      shift
+      ;;
     *)
       echo "::error file=$0::unrecognized option: $1"
       exit 3
@@ -201,30 +211,55 @@ if [[ $RUNNER_OS == macOS ]]; then
   # this works independent of the qt version as there should be only one version installed on the runner at a time
   export QTDIR
 
-  if [[ $TARGET_MACOS_VERSION ]]; then
-    # CMAKE_OSX_DEPLOYMENT_TARGET is a vanilla cmake flag needed to compile to target macOS version
-    flags+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=$TARGET_MACOS_VERSION")
-
-    # vcpkg dependencies need a vcpkg triplet file to compile to the target macOS version
-    # an easy way is to copy the x64-osx.cmake file and modify it
+  if [[ $TARGET_MACOS_VERSION || $TARGET_MACOS_ARCH ]]; then
+    # if we are using either a custom version or architecture, we need to use a custom triplet file to compile *vcpkg dependencies*
+    # https://learn.microsoft.com/en-us/vcpkg/concepts/triplets
+    # an easy way to get a custom triplet file is to copy a triplet file from the vcpkg repo and then modify it
     triplets_dir="/tmp/cmake/triplets"
     triplet_version="custom-triplet"
     triplet_file="$triplets_dir/$triplet_version.cmake"
-    arch=$(uname -m)
-    if [[ $arch == x86_64 ]]; then
-      arch="x64"
-    fi
     mkdir -p "$triplets_dir"
-    triplet_source="../vcpkg/triplets/$arch-osx.cmake"
-    if [[ ! -f "$triplet_source" ]]; then
-      triplet_source="../vcpkg/triplets/community/$arch-osx.cmake"
-    fi
-    cp "$triplet_source" "$triplet_file"
-    echo "set(VCPKG_CMAKE_SYSTEM_VERSION $TARGET_MACOS_VERSION)" >>"$triplet_file"
-    echo "set(VCPKG_OSX_DEPLOYMENT_TARGET $TARGET_MACOS_VERSION)" >>"$triplet_file"
+    # vcpkg-specific CMake flags needed to use the custom triplet file
+    # both host and target triplet are set to be the same in order to avoid building dependencies twice
     flags+=("-DVCPKG_OVERLAY_TRIPLETS=$triplets_dir")
     flags+=("-DVCPKG_HOST_TRIPLET=$triplet_version")
     flags+=("-DVCPKG_TARGET_TRIPLET=$triplet_version")
+
+    # vcpkg triplet file variables that will be appended later to the generated custom triplet file
+    # https://learn.microsoft.com/en-us/vcpkg/users/triplets
+    declare -a extra_triplet_vars
+
+    if [[ $TARGET_MACOS_ARCH ]]; then
+      # CMAKE_OSX_ARCHITECTURES is a vanilla CMake flag needed to compile cockatrice to target macOS architecture
+      flags+=("-DCMAKE_OSX_ARCHITECTURES=$TARGET_MACOS_ARCH")
+      # for example, by using x64-osx.cmake, even on arm64 macOS, vcpkg will (cross-) compile for x86_64
+      triplet_arch=$TARGET_MACOS_ARCH
+    else
+      triplet_arch=$(uname -m)
+    fi
+
+    if [[ $TARGET_MACOS_VERSION ]]; then
+      # CMAKE_OSX_DEPLOYMENT_TARGET is a vanilla CMake flag needed to compile cockatrice to target macOS version
+      flags+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=$TARGET_MACOS_VERSION")
+      extra_triplet_vars+=("set(VCPKG_CMAKE_SYSTEM_VERSION $TARGET_MACOS_VERSION)")
+      extra_triplet_vars+=("set(VCPKG_OSX_DEPLOYMENT_TARGET $TARGET_MACOS_VERSION)")
+    fi
+
+    if [[ $triplet_arch == x86_64 ]]; then
+      # vcpkg uses x64-osx.cmake as default for x86_64
+      triplet_arch="x64"
+    fi
+
+    # generate the custom triplet file
+    triplet_source="../vcpkg/triplets/$triplet_arch-osx.cmake"
+    if [[ ! -f "$triplet_source" ]]; then
+      triplet_source="../vcpkg/triplets/community/$triplet_arch-osx.cmake"
+    fi
+    cp "$triplet_source" "$triplet_file"
+    for var in "${extra_triplet_vars[@]}"; do
+      echo "$var" >>"$triplet_file"
+    done
+
     echo "::group::Generated triplet $triplet_file"
     cat "$triplet_file"
     echo "::endgroup::"

--- a/.ci/thin_macos_qtlib.sh
+++ b/.ci/thin_macos_qtlib.sh
@@ -5,8 +5,24 @@
 
 # This script is meant to be used by the ci enironment on macos runners only.
 # It uses the runner's GITHUB_WORKSPACE env variable.
-arch=$(uname -m)
+# 'soc' argument specifies the target system on chip (SoC) architecture, e.g., 'Intel' for x86_64
+# Example usage:
+#   ./thin_macos_qtlib.sh Intel    # Thins binaries to x86_64
+#   ./thin_macos_qtlib.sh Apple    # Thins binaries to arm64
+
+
+soc=$1
 nproc=$(sysctl -n hw.ncpu)
+
+if [[ $soc == 'Intel' ]]; then
+  arch='x86_64'
+elif [[ $soc == 'Apple' ]]; then
+  arch='arm64'
+else
+  echo "Invalid 'soc' argument: $soc"
+  echo "Usage: ./thin_macos_qtlib.sh [Intel|Apple]"
+  exit 1
+fi
 
 function thin() {
   local libfile=$1

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "[macOS] Create thin Qt libraries"
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
-        run: .ci/thin_macos_qtlib.sh
+        run: .ci/thin_macos_qtlib.sh ${{ matrix.soc }}
 
       - name: "[macOS] Cache thin Qt libraries"
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -263,7 +263,7 @@ jobs:
         include:
           - os: macOS
             target: 13
-            runner: macos-15-intel
+            runner: macos-15
 
             ccache_eviction_age: 7d
             cmake_generator: Ninja
@@ -461,6 +461,7 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
           MAKE_PACKAGE: '${{ matrix.make_package }}'
           PACKAGE_SUFFIX: '${{ matrix.package_suffix }}'
+          TARGET_MACOS_ARCH: ${{ matrix.soc == 'Intel' && 'x86_64' || '' }}
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
           VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
           VCPKG_DISABLE_METRICS: 1


### PR DESCRIPTION
### **User description**
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem


## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add cross-compilation support for macOS x86_64 on arm64 runners

- Introduce `--target-macos-architecture` parameter to compile script

- Update thin Qt libraries script to accept architecture parameter

- Set up vcpkg triplet customization for target architecture


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User specifies<br/>target architecture"] -->|"--target-macos-architecture"| B["compile.sh"]
  B -->|"CMAKE_OSX_ARCHITECTURES"| C["CMake configuration"]
  B -->|"Custom triplet file"| D["vcpkg dependencies"]
  E["CI workflow"] -->|"matrix.soc parameter"| F["thin_macos_qtlib.sh"]
  F -->|"lipo with arch"| G["Thinned Qt libraries"]
  C --> H["Cross-compiled binary"]
  D --> H
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.sh</strong><dd><code>Add macOS cross-compilation architecture support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.ci/compile.sh

<ul><li>Added <code>--target-macos-architecture</code> command-line argument to specify <br>target macOS architecture<br> <li> Refactored macOS build configuration to handle both custom version and <br>architecture<br> <li> Implemented vcpkg triplet file generation with support for <br>cross-compilation<br> <li> Added <code>CMAKE_OSX_ARCHITECTURES</code> CMake flag for architecture targeting<br> <li> Improved triplet variable management using array for cleaner code <br>organization</ul>


</details>


  </td>
  <td><a href="https://github.com/brunoalr/Cockatrice/pull/29/files#diff-932e7912a6f0fbffc7af594790541edb262ac9c9641f687738fdbba10e1da4d8">+49/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>thin_macos_qtlib.sh</strong><dd><code>Parameterize Qt library thinning script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.ci/thin_macos_qtlib.sh

<ul><li>Added <code>soc</code> parameter to accept target architecture specification (Intel <br>or Apple)<br> <li> Implemented conditional logic to map SoC names to architecture strings <br>(x86_64 or arm64)<br> <li> Added input validation with usage instructions<br> <li> Removed hardcoded architecture detection via <code>uname -m</code></ul>


</details>


  </td>
  <td><a href="https://github.com/brunoalr/Cockatrice/pull/29/files#diff-f80bc5bd1c979a5c915cde4cfefb69fef2b7e6a83251c04b1495e68cbf399e8c">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>desktop-build.yml</strong><dd><code>Update workflow for cross-compilation configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/desktop-build.yml

<ul><li>Changed macOS runner from <code>macos-15-intel</code> to <code>macos-15</code> for <br>cross-compilation testing<br> <li> Updated thin Qt libraries step to pass <code>matrix.soc</code> parameter<br> <li> Added <code>TARGET_MACOS_ARCH</code> environment variable set based on SoC type<br> <li> Conditional architecture setting: x86_64 for Intel, empty for Apple <br>Silicon</ul>


</details>


  </td>
  <td><a href="https://github.com/brunoalr/Cockatrice/pull/29/files#diff-73d26ed8f688bf0bdc3abc2d453358c8f72c00a45c082b2a2ecae0972018a8fe">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

