### PR TITLE
ci: use Github Packages NuGet feed to cache vcpkg

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -5,6 +5,7 @@ permissions:
   id-token: write
   attestations: write
   actions: write # needed for ccache action to be able to delete gha caches
+  packages: write # needed to upload vcpkg caches to GitHub Packages
 
 on:
   push:
@@ -265,6 +266,16 @@ jobs:
         run: gh attestation verify ${{steps.build.outputs.path}} --repo Cockatrice/Cockatrice
 
   build-vcpkg:
+    env:
+      USERNAME: brunoalr
+      VCPKG_EXE: ${{ github.workspace }}/vcpkg/vcpkg
+      FEED_URL: https://nuget.pkg.github.com/brunoalr/index.json
+      VCPKG_DISABLE_METRICS: 1
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/brunoalr/index.json,readwrite"
+      # Cache size over the entire repo is 10Gi:
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      CCACHE_DIR: ${{github.workspace}}/.cache/
+      CCACHE_SIZE: 550M
     strategy:
       fail-fast: false
       matrix:
@@ -281,6 +292,7 @@ jobs:
             qt_version: 6.11.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
+            cache_qt: false
             cmake_generator: Ninja
             use_ccache: 1
             ccache_eviction_age: 7d
@@ -344,17 +356,59 @@ jobs:
     needs: configure
     runs-on: ${{matrix.runner}}
     timeout-minutes: 100
-    env:
-      CCACHE_DIR: ${{github.workspace}}/.cache/
-      # Cache size over the entire repo is 10Gi:
-      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
-      CCACHE_SIZE: 550M
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Install Mono (macOS)
+        if: matrix.os == 'macOS'
+        shell: bash
+        run: brew install mono
+
+      - name: Bootstrap vcpkg (macOS)
+        if: matrix.os == 'macOS'
+        shell: bash
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Bootstrap vcpkg (Windows)
+        if: matrix.os == 'Windows'
+        shell: pwsh
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+
+      - name: Add NuGet sources (macOS)
+        if: matrix.os == 'macOS'
+        shell: bash
+        env:
+          VCPKG_EXE: ${{ github.workspace }}/vcpkg/vcpkg
+        run: |
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            sources add \
+            -Source "${{ env.FEED_URL }}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${{ env.USERNAME }}" \
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "${{ env.FEED_URL }}"
+
+      - name: Add NuGet sources (Windows)
+        if: matrix.os == 'Windows'
+        shell: pwsh
+        run: |
+          .$(${{ env.VCPKG_EXE }} fetch nuget) `
+            sources add `
+            -Source "${{ env.FEED_URL }}" `
+            -StorePasswordInClearText `
+            -Name GitHubPackages `
+            -UserName "${{ env.USERNAME }}" `
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          .$(${{ env.VCPKG_EXE }} fetch nuget) `
+            setapikey "${{ secrets.GITHUB_TOKEN }}" `
+            -Source "${{ env.FEED_URL }}"
 
       - name: Add msbuild to PATH
         if: matrix.os == 'Windows'
@@ -434,12 +488,6 @@ jobs:
         shell: bash
         run: choco install nsis
 
-      - name: Setup vcpkg cache
-        id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       # uses environment variables, see compile.sh for more details
       - name: Build Cockatrice
         id: build
@@ -451,8 +499,6 @@ jobs:
           CMAKE_GENERATOR: ${{matrix.cmake_generator}}
           CMAKE_GENERATOR_PLATFORM: ${{matrix.cmake_generator_platform}}
           USE_CCACHE: ${{matrix.use_ccache}}
-          VCPKG_DISABLE_METRICS: 1
-          VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
           # macOS-specific environment variables, will be ignored on Windows
           MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -5,6 +5,7 @@ permissions:
   attestations: write    # needed to persist the attestation.
   contents: write
   id-token: write    # needed for signing certificate in attestation
+  packages: write    # needed to upload vcpkg caches to GitHub Packages
 
 on:
   push:
@@ -260,6 +261,16 @@ jobs:
         run: gh attestation verify "${{ steps.build.outputs.path }}" --repo Cockatrice/Cockatrice
 
   build-vcpkg:
+    env:
+      USERNAME: brunoalr
+      VCPKG_EXE: ${{ github.workspace }}/vcpkg/vcpkg
+      FEED_URL: https://nuget.pkg.github.com/brunoalr/index.json
+      VCPKG_DISABLE_METRICS: 1
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/brunoalr/index.json,readwrite"
+      # Cache size over the entire repo is 10Gi:
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      CCACHE_DIR: ${{github.workspace}}/.cache/
+      CCACHE_SIZE: 550M
     strategy:
       fail-fast: false
       matrix:
@@ -344,15 +355,59 @@ jobs:
     needs: configure
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 100
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/.cache/
-      CCACHE_SIZE: 550M    # space of all repo is 10Gi: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
 
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: "[macOS] Install Mono"
+        if: matrix.os == 'macOS'
+        shell: bash
+        run: brew install mono
+
+      - name: "[macOS] Bootstrap vcpkg"
+        if: matrix.os == 'macOS'
+        shell: bash
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: "[Windows] Bootstrap vcpkg"
+        if: matrix.os == 'Windows'
+        shell: pwsh
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+
+      - name: "[macOS] Add NuGet sources"
+        if: matrix.os == 'macOS'
+        shell: bash
+        env:
+          VCPKG_EXE: ${{ github.workspace }}/vcpkg/vcpkg
+        run: |
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            sources add \
+            -Source "${{ env.FEED_URL }}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${{ env.USERNAME }}" \
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "${{ env.FEED_URL }}"
+
+      - name: "[Windows] Add NuGet sources"
+        if: matrix.os == 'Windows'
+        shell: pwsh
+        run: |
+          .$(${{ env.VCPKG_EXE }} fetch nuget) `
+            sources add `
+            -Source "${{ env.FEED_URL }}" `
+            -StorePasswordInClearText `
+            -Name GitHubPackages `
+            -UserName "${{ env.USERNAME }}" `
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          .$(${{ env.VCPKG_EXE }} fetch nuget) `
+            setapikey "${{ secrets.GITHUB_TOKEN }}" `
+            -Source "${{ env.FEED_URL }}"
 
       - name: "[Windows] Add msbuild to PATH"
         if: matrix.os == 'Windows'
@@ -432,12 +487,6 @@ jobs:
         shell: bash
         run: choco install nsis
 
-      - name: "Setup vcpkg cache"
-        id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       # Uses environment variables, see compile.sh for more details
       - name: "Build Cockatrice"
         id: build
@@ -456,8 +505,6 @@ jobs:
           PACKAGE_SUFFIX: '${{ matrix.package_suffix }}'
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
           USE_CCACHE: ${{ matrix.use_ccache }}
-          VCPKG_BINARY_SOURCES: 'clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite'
-          VCPKG_DISABLE_METRICS: 1
         run: .ci/compile.sh --server --test --vcpkg
 
       # Delete used cache to emulate a ccache update. See https://github.com/actions/cache/issues/342


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem


## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches vcpkg caching to GitHub Packages (NuGet) and adds a workflow to clean up runner caches on closed PRs.
> 
> - **CI workflows**:
>   - **New cleanup workflow**: Adds `.github/workflows/delete-merged-caches.yml` to delete GitHub Actions caches when PRs close using `gh cache`.
> - **Desktop build pipeline** (`.github/workflows/desktop-build.yml`):
>   - Permissions: grant `packages: write` for publishing vcpkg caches.
>   - **vcpkg caching via GitHub Packages (NuGet)**:
>     - Define env: `USERNAME`, `VCPKG_EXE`, `FEED_URL`, `VCPKG_DISABLE_METRICS`, `VCPKG_BINARY_SOURCES`.
>     - Install Mono on macOS; bootstrap vcpkg on macOS/Windows.
>     - Add NuGet source/auth on macOS and Windows using `${{ secrets.GITHUB_TOKEN }}`.
>     - Remove previous `TAServers/vcpkg-cache` action and related `VCPKG_BINARY_SOURCES` file-cache env.
>   - Minor: keep Qt caching config; no product build logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2013b52015b6d421638891154f5a3b85a9461792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->