### PR TITLE
fix: manage ccache caches manually on macos

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -342,6 +342,8 @@ jobs:
     name: ${{matrix.os}} ${{matrix.target}}${{ matrix.soc == 'Intel' && ' Intel' || '' }}${{ matrix.type == 'Debug' && ' Debug' || '' }}
     needs: configure
     runs-on: ${{matrix.runner}}
+    env:
+      CACHE: ${{github.workspace}}/.cache/
 
     steps:
       - name: Checkout
@@ -356,16 +358,16 @@ jobs:
         with:
           msbuild-architecture: x64
 
-      # Using jianmingyong/ccache-action to setup ccache without using brew
-      # It tries to download a binary of ccache from GitHub Release and falls back to building from source if it fails
-      - name: Setup ccache
+      - name: Restore compiler cache (ccache)
         if: matrix.use_ccache == 1
-        uses: jianmingyong/ccache-action@v1
+        id: ccache_restore
+        uses: actions/cache/restore@v5
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          install-type: "binary"
-          ccache-key-prefix: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}
-          max-size: 500M
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{env.CACHE}}
+          key: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}
+          restore-keys: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}
 
       - name: Install Qt ${{matrix.qt_version}}
         uses: jurplel/install-qt-action@v4
@@ -402,6 +404,13 @@ jobs:
           DEVELOPER_DIR: '/Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer'
           TARGET_MACOS_VERSION: ${{ matrix.override_target }}
         run: .ci/compile.sh --server --test --vcpkg
+
+      - name: Save compiler cache (ccache)
+        if: github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{env.CACHE}}
+          key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
       - name: Sign app bundle
         if: matrix.os == 'macOS' && matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -358,6 +358,10 @@ jobs:
         with:
           msbuild-architecture: x64
 
+      - name: Setup ccache
+        if: matrix.use_ccache == 1 && matrix.os == 'macOS'
+        run: brew install ccache
+
       - name: Restore compiler cache (ccache)
         if: matrix.use_ccache == 1
         id: ccache_restore

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -343,7 +343,7 @@ jobs:
     needs: configure
     runs-on: ${{matrix.runner}}
     env:
-      CACHE: ${{github.workspace}}/.cache/
+      CCACHE_DIR: ${{github.workspace}}/.cache/
 
     steps:
       - name: Checkout
@@ -369,9 +369,9 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          path: ${{env.CACHE}}
-          key: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}
-          restore-keys: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}
+          path: ${{env.CCACHE_DIR}}
+          key: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}-${{env.BRANCH_NAME}}
+          restore-keys: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}-
 
       - name: Install Qt ${{matrix.qt_version}}
         uses: jurplel/install-qt-action@v4
@@ -410,11 +410,13 @@ jobs:
         run: .ci/compile.sh --server --test --vcpkg
 
       - name: Save compiler cache (ccache)
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && matrix.use_ccache == 1
         uses: actions/cache/save@v5
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          path: ${{env.CACHE}}
-          key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
+          path: ${{env.CCACHE_DIR}}
+          key: ccache-${{matrix.runner}}-${{matrix.soc}}-${{matrix.type}}-${{env.BRANCH_NAME}}
 
       - name: Sign app bundle
         if: matrix.os == 'macOS' && matrix.make_package && (github.ref == 'refs/heads/master' || needs.configure.outputs.tag != null)

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -344,6 +344,9 @@ jobs:
     runs-on: ${{matrix.runner}}
     env:
       CCACHE_DIR: ${{github.workspace}}/.cache/
+      # Cache size over the entire repo is 10Gi:
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      CCACHE_SIZE: 500M
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem


## What will change with this Pull Request?
- this
- and this

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces manual ccache management in CI and adds cache cleanup automation.
> 
> - **Workflows:** New `delete-merged-caches.yml` cleans up GitHub Actions caches when PRs are closed using `gh cache` and PR merge ref
> - **Desktop build:** Set `CCACHE_DIR`/`CCACHE_SIZE` envs and replace `jianmingyong/ccache-action` with `actions/cache` restore/save for ccache on macOS/Windows matrix; save only on `master`
> - No build logic changes beyond cache handling; signing/notarization and packaging remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd0ff8c470b60823b6ddff847fb412d29fab4838. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->