### PR TITLE
feat: enable expressions in card counters

### DIFF
--- a/.ci/Ubuntu26.04/Dockerfile
+++ b/.ci/Ubuntu26.04/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:26.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        ccache \
+        clang-format \
+        cmake \
+        file \
+        g++ \
+        git \
+        libgl-dev \
+        liblzma-dev \
+        libmariadb-dev-compat \
+        libprotobuf-dev \
+        libqt6multimedia6 \
+        libqt6sql6-mysql \
+        ninja-build \
+        protobuf-compiler \
+        qt6-image-formats-plugins \
+        qt6-l10n-tools \
+        qt6-multimedia-dev \
+        qt6-svg-dev \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+        qt6-websockets-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.ci/release_template.md
+++ b/.ci/release_template.md
@@ -17,6 +17,7 @@ Available pre-compiled binaries for installation:
    • <kbd>macOS 13+</kbd> <sub><i>Ventura</i></sub> <sub>Intel</sub>
 
   <b>Linux</b>
+   • <kbd>Ubuntu 26.04 LTS</kbd> <sub><i>Resolute Racoon</i></sub>
    • <kbd>Ubuntu 24.04 LTS</kbd> <sub><i>Noble Numbat</i></sub>
    • <kbd>Ubuntu 22.04 LTS</kbd> <sub><i>Jammy Jellyfish</i></sub>
    • <kbd>Debian 13</kbd> <sub><i>Trixie</i></sub>

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -142,9 +142,14 @@ jobs:
           - distro: Ubuntu
             version: 22.04
             package: DEB
+            test: skip    # Running tests on all distros is superfluous
 
           - distro: Ubuntu
             version: 24.04
+            package: DEB
+
+          - distro: Ubuntu
+            version: 26.04
             package: DEB
 
     name: ${{matrix.distro}} ${{matrix.version}}

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1576,44 +1576,37 @@ void PlayerActions::actCardCounterTrigger()
         case 11: { // set counter with dialog
             player->setDialogSemaphore(true);
 
-            const auto &cardCounterSettings = SettingsCache::instance().cardCounters();
-            const auto &counterName = cardCounterSettings.displayName(counterId);
+            // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
+            QList<QGraphicsItem *> sel = player->getGameScene()->selectedItems();
+            QString oldValueForDlg = "x";
+            if (sel.size() == 1) {
+                auto *card = dynamic_cast<CardItem *>(sel.first());
+                oldValueForDlg = QString::number(card->getCounters().value(counterId, 0));
+            }
 
-            const auto &selectedItems = player->getGameScene()->selectedItems();
-
-            const QString oldValueForDlg = [&selectedItems, &counterId] {
-                // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
-                if (selectedItems.size() == 1) {
-                    const auto *card = dynamic_cast<CardItem *>(selectedItems.first());
-                    return QString::number(card->getCounters().value(counterId, 0));
-                }
-                return QString{"x"};
-            }();
+            auto &cardCounterSettings = SettingsCache::instance().cardCounters();
+            QString counterName = cardCounterSettings.displayName(counterId);
 
             AbstractCounterDialog dialog(counterName, oldValueForDlg, player->getGame()->getTab());
-            const int ok = dialog.exec();
-
-            if (!ok) {
-                return;
-            }
+            int ok = dialog.exec();
 
             player->setDialogSemaphore(false);
             if (player->clearCardsToDelete() || !ok) {
                 return;
             }
 
-            for (const auto &item : selectedItems) {
-                const auto *card = dynamic_cast<CardItem *>(item);
+            for (const auto &item : sel) {
+                auto *card = dynamic_cast<CardItem *>(item);
 
-                const auto oldValue = card->getCounters().value(counterId, 0);
+                int oldValue = card->getCounters().value(counterId, 0);
                 Expression exp(oldValue);
-                const auto newValue = static_cast<int>(exp.parse(dialog.textValue()));
+                int number = static_cast<int>(exp.parse(dialog.textValue()));
 
                 auto *cmd = new Command_SetCardCounter;
                 cmd->set_zone(card->getZone()->getName().toStdString());
                 cmd->set_card_id(card->getId());
                 cmd->set_counter_id(counterId);
-                cmd->set_counter_value(newValue);
+                cmd->set_counter_value(number);
                 commandList.append(cmd);
             }
             break;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -3,14 +3,13 @@
 #include "../../interface/widgets/tabs/tab_game.h"
 #include "../../interface/widgets/utility/get_text_with_max.h"
 #include "../board/card_item.h"
+#include "../client/settings/card_counter_settings.h"
 #include "../dialogs/dlg_move_top_cards_until.h"
 #include "../dialogs/dlg_roll_dice.h"
 #include "../zones/hand_zone.h"
 #include "../zones/logic/view_zone_logic.h"
 #include "../zones/table_zone.h"
 #include "card_menu_action_type.h"
-#include "libcockatrice/utility/expression.h"
-#include "../client/settings/card_counter_settings.h"
 
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/card/relation/card_relation.h>
@@ -29,6 +28,7 @@
 #include <libcockatrice/protocol/pb/command_shuffle.pb.h>
 #include <libcockatrice/protocol/pb/command_undo_draw.pb.h>
 #include <libcockatrice/protocol/pb/context_move_card.pb.h>
+#include <libcockatrice/utility/expression.h>
 #include <libcockatrice/utility/trice_limits.h>
 #include <libcockatrice/utility/zone_names.h>
 

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -9,6 +9,8 @@
 #include "../zones/logic/view_zone_logic.h"
 #include "../zones/table_zone.h"
 #include "card_menu_action_type.h"
+#include "libcockatrice/utility/expression.h"
+#include "../client/settings/card_counter_settings.h"
 
 #include <libcockatrice/card/database/card_database_manager.h>
 #include <libcockatrice/card/relation/card_relation.h>
@@ -1572,23 +1574,35 @@ void PlayerActions::actCardCounterTrigger()
             break;
         }
         case 11: { // set counter with dialog
-            bool ok;
             player->setDialogSemaphore(true);
 
             int oldValue = 0;
-            if (player->getGameScene()->selectedItems().size() == 1) {
-                auto *card = static_cast<CardItem *>(player->getGameScene()->selectedItems().first());
+            QString counterName = "";
+
+            if (auto selectedItems = player->getGameScene()->selectedItems(); selectedItems.size() == 1) {
+                const auto *card = dynamic_cast<CardItem *>(selectedItems.first());
+                const auto &cardCounterSettings = SettingsCache::instance().cardCounters();
+                counterName = cardCounterSettings.displayName(counterId);
                 oldValue = card->getCounters().value(counterId, 0);
             }
-            int number = QInputDialog::getInt(player->getGame()->getTab(), tr("Set counters"), tr("Number:"), oldValue,
-                                              0, MAX_COUNTERS_ON_CARD, 1, &ok);
+
+            AbstractCounterDialog dialog(counterName, QString::number(oldValue), player->getGame()->getTab());
+            const int ok = dialog.exec();
+
+            if (!ok) {
+                return;
+            }
+
+            Expression exp(oldValue);
+            const auto number = static_cast<int>(exp.parse(dialog.textValue()));
+
             player->setDialogSemaphore(false);
             if (player->clearCardsToDelete() || !ok) {
                 return;
             }
 
             for (const auto &item : player->getGameScene()->selectedItems()) {
-                auto *card = static_cast<CardItem *>(item);
+                const auto *card = dynamic_cast<CardItem *>(item);
                 auto *cmd = new Command_SetCardCounter;
                 cmd->set_zone(card->getZone()->getName().toStdString());
                 cmd->set_card_id(card->getId());

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1605,8 +1605,8 @@ void PlayerActions::actCardCounterTrigger()
             for (const auto &item : selectedItems) {
                 const auto *card = dynamic_cast<CardItem *>(item);
 
-                const auto oldValue = QString::number(card->getCounters().value(counterId, 0));
-                Expression exp(oldValue.toDouble());
+                const auto oldValue = card->getCounters().value(counterId, 0);
+                Expression exp(oldValue);
                 const auto newValue = static_cast<int>(exp.parse(dialog.textValue()));
 
                 auto *cmd = new Command_SetCardCounter;

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1577,9 +1577,9 @@ void PlayerActions::actCardCounterTrigger()
             player->setDialogSemaphore(true);
 
             const auto &cardCounterSettings = SettingsCache::instance().cardCounters();
-            const auto counterName = cardCounterSettings.displayName(counterId);
+            const auto &counterName = cardCounterSettings.displayName(counterId);
 
-            auto selectedItems = player->getGameScene()->selectedItems();
+            const auto &selectedItems = player->getGameScene()->selectedItems();
 
             const QString oldValueForDlg = [&selectedItems, &counterId] {
                 // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"

--- a/cockatrice/src/game/player/player_actions.cpp
+++ b/cockatrice/src/game/player/player_actions.cpp
@@ -1576,38 +1576,44 @@ void PlayerActions::actCardCounterTrigger()
         case 11: { // set counter with dialog
             player->setDialogSemaphore(true);
 
-            int oldValue = 0;
-            QString counterName = "";
+            const auto &cardCounterSettings = SettingsCache::instance().cardCounters();
+            const auto counterName = cardCounterSettings.displayName(counterId);
 
-            if (auto selectedItems = player->getGameScene()->selectedItems(); selectedItems.size() == 1) {
-                const auto *card = dynamic_cast<CardItem *>(selectedItems.first());
-                const auto &cardCounterSettings = SettingsCache::instance().cardCounters();
-                counterName = cardCounterSettings.displayName(counterId);
-                oldValue = card->getCounters().value(counterId, 0);
-            }
+            auto selectedItems = player->getGameScene()->selectedItems();
 
-            AbstractCounterDialog dialog(counterName, QString::number(oldValue), player->getGame()->getTab());
+            const QString oldValueForDlg = [&selectedItems, &counterId] {
+                // If a single card is selected, we show the old value in the dialog. Otherwise, we show "x"
+                if (selectedItems.size() == 1) {
+                    const auto *card = dynamic_cast<CardItem *>(selectedItems.first());
+                    return QString::number(card->getCounters().value(counterId, 0));
+                }
+                return QString{"x"};
+            }();
+
+            AbstractCounterDialog dialog(counterName, oldValueForDlg, player->getGame()->getTab());
             const int ok = dialog.exec();
 
             if (!ok) {
                 return;
             }
 
-            Expression exp(oldValue);
-            const auto number = static_cast<int>(exp.parse(dialog.textValue()));
-
             player->setDialogSemaphore(false);
             if (player->clearCardsToDelete() || !ok) {
                 return;
             }
 
-            for (const auto &item : player->getGameScene()->selectedItems()) {
+            for (const auto &item : selectedItems) {
                 const auto *card = dynamic_cast<CardItem *>(item);
+
+                const auto oldValue = QString::number(card->getCounters().value(counterId, 0));
+                Expression exp(oldValue.toDouble());
+                const auto newValue = static_cast<int>(exp.parse(dialog.textValue()));
+
                 auto *cmd = new Command_SetCardCounter;
                 cmd->set_zone(card->getZone()->getName().toStdString());
                 cmd->set_card_id(card->getId());
                 cmd->set_counter_id(counterId);
-                cmd->set_counter_value(number);
+                cmd->set_counter_value(newValue);
                 commandList.append(cmd);
             }
             break;

--- a/cockatrice/src/interface/widgets/tabs/tab_replays.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_replays.cpp
@@ -30,6 +30,8 @@
 #include <libcockatrice/protocol/pb/response_replay_get_code.pb.h>
 #include <libcockatrice/protocol/pending_command.h>
 
+inline Q_LOGGING_CATEGORY(TabReplaysLog, "replays_tab");
+
 TabReplays::TabReplays(TabSupervisor *_tabSupervisor, AbstractClient *_client, const ServerInfo_User *currentUserInfo)
     : Tab(_tabSupervisor), client(_client)
 {
@@ -265,9 +267,11 @@ void TabReplays::actOpenLocalReplay()
         f.close();
 
         GameReplay *replay = new GameReplay;
-        replay->ParseFromArray(_data.data(), _data.size());
-
-        emit openReplay(replay);
+        if (replay->ParseFromArray(_data.data(), _data.size())) {
+            emit openReplay(replay);
+        } else {
+            qCWarning(TabReplaysLog) << "could not parse replay!";
+        }
     }
 }
 
@@ -379,9 +383,12 @@ void TabReplays::openRemoteReplayFinished(const Response &r)
 
     const Response_ReplayDownload &resp = r.GetExtension(Response_ReplayDownload::ext);
     GameReplay *replay = new GameReplay;
-    replay->ParseFromString(resp.replay_data());
+    if (replay->ParseFromString(resp.replay_data())) {
 
-    emit openReplay(replay);
+        emit openReplay(replay);
+    } else {
+        qCWarning(TabReplaysLog) << "could not parse remote replay!";
+    }
 }
 
 void TabReplays::actDownload()

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -84,6 +84,7 @@
 const QString MainWindow::appName = "Cockatrice";
 const QStringList MainWindow::fileNameFilters = QStringList() << QObject::tr("Cockatrice card database (*.xml)")
                                                               << QObject::tr("All files (*.*)");
+inline Q_LOGGING_CATEGORY(MainWindowLog, "main_window");
 
 /**
  * Replaces the tab-specific menus that are shown in the menuBar.
@@ -277,9 +278,11 @@ void MainWindow::actWatchReplay()
     file.close();
 
     replay = new GameReplay;
-    replay->ParseFromArray(buf.data(), buf.size());
-
-    tabSupervisor->openReplay(replay);
+    if (replay->ParseFromArray(buf.data(), buf.size())) {
+        tabSupervisor->openReplay(replay);
+    } else {
+        qCWarning(MainWindowLog) << "failed to parse replay!";
+    }
 }
 
 void MainWindow::localGameEnded()

--- a/libcockatrice_network/libcockatrice/network/client/remote/remote_client.cpp
+++ b/libcockatrice_network/libcockatrice/network/client/remote/remote_client.cpp
@@ -390,14 +390,18 @@ void RemoteClient::readData()
             return;
 
         ServerMessage newServerMessage;
-        newServerMessage.ParseFromArray(inputBuffer.data(), messageLength);
-
-        qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
+        bool ok = newServerMessage.ParseFromArray(inputBuffer.data(), messageLength);
 
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 
-        processProtocolItem(newServerMessage);
+        if (ok) {
+            qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
+
+            processProtocolItem(newServerMessage);
+        } else {
+            qCDebug(RemoteClientLog) << "parsing error!";
+        }
 
         if (getStatus() == StatusDisconnecting) // use thread-safe getter
             doDisconnectFromServer();
@@ -408,11 +412,13 @@ void RemoteClient::websocketMessageReceived(const QByteArray &message)
 {
     lastDataReceived = timeRunning;
     ServerMessage newServerMessage;
-    newServerMessage.ParseFromArray(message.data(), message.length());
+    if (newServerMessage.ParseFromArray(message.data(), message.length())) {
+        qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
 
-    qCDebug(RemoteClientLog).noquote() << "IN" << getSafeDebugString(newServerMessage);
-
-    processProtocolItem(newServerMessage);
+        processProtocolItem(newServerMessage);
+    } else {
+        qCDebug(RemoteClientLog) << "parsing error!";
+    }
 }
 
 void RemoteClient::sendCommandContainer(const CommandContainer &cont)
@@ -426,19 +432,27 @@ void RemoteClient::sendCommandContainer(const CommandContainer &cont)
     qCDebug(RemoteClientLog).noquote() << "OUT" << getSafeDebugString(cont);
 
     QByteArray buf;
+    bool ok;
     if (usingWebSocket) {
         buf.resize(size);
-        cont.SerializeToArray(buf.data(), size);
-        websocket->sendBinaryMessage(buf);
+        ok = cont.SerializeToArray(buf.data(), size);
+        if (ok) {
+            websocket->sendBinaryMessage(buf);
+        }
     } else {
         buf.resize(size + 4);
-        cont.SerializeToArray(buf.data() + 4, size);
-        buf.data()[3] = (unsigned char)size;
-        buf.data()[2] = (unsigned char)(size >> 8);
-        buf.data()[1] = (unsigned char)(size >> 16);
-        buf.data()[0] = (unsigned char)(size >> 24);
+        ok = cont.SerializeToArray(buf.data() + 4, size);
+        if (ok) {
+            buf.data()[3] = (unsigned char)size;
+            buf.data()[2] = (unsigned char)(size >> 8);
+            buf.data()[1] = (unsigned char)(size >> 16);
+            buf.data()[0] = (unsigned char)(size >> 24);
 
-        socket->write(buf);
+            socket->write(buf);
+        }
+    }
+    if (!ok) {
+        qCDebug(RemoteClientLog) << "transmit error!";
     }
 }
 

--- a/libcockatrice_protocol/libcockatrice/protocol/debug_pb_message.cpp
+++ b/libcockatrice_protocol/libcockatrice/protocol/debug_pb_message.cpp
@@ -101,6 +101,10 @@ QString getSafeDebugString(const ::google::protobuf::Message &message)
 #endif // GOOGLE_PROTOBUF_VERSION > 3004000
 
     std::string debug_string;
-    printer.PrintToString(message, &debug_string);
-    return QString::number(size) + " bytes " + QString::fromStdString(debug_string);
+    bool ok = printer.PrintToString(message, &debug_string);
+    if (ok) {
+        return QString::number(size) + " bytes " + QString::fromStdString(debug_string);
+    } else {
+        return "[could not convert message to string]";
+    }
 }

--- a/libcockatrice_utility/libcockatrice/utility/expression.cpp
+++ b/libcockatrice_utility/libcockatrice/utility/expression.cpp
@@ -20,7 +20,7 @@ peg::parser math(R"(
 
     NUMBER       <-  < '-'? [0-9]+ >
     NAME         <-  < [a-z][a-z0-9]* >
-    VARIABLE     <-  < [x] >
+    VARIABLE     <-  < [xX] >
     FUNCTION     <-  NAME '(' EXPRESSION ( [,\n] EXPRESSION )* ')'
 
     %whitespace  <-  [ \t\r]*

--- a/servatrice/src/isl_interface.cpp
+++ b/servatrice/src/isl_interface.cpp
@@ -3,6 +3,7 @@
 #include "main.h"
 #include "server_logger.h"
 
+#include <QLoggingCategory>
 #include <QSslSocket>
 #include <google/protobuf/descriptor.h>
 #include <libcockatrice/protocol/debug_pb_message.h>
@@ -20,6 +21,8 @@
 #include <libcockatrice/protocol/pb/isl_message.pb.h>
 #include <server_protocolhandler.h>
 #include <server_room.h>
+
+inline Q_LOGGING_CATEGORY(IslInterfaceLog, "isl_interface");
 
 void IslInterface::sharedCtor(const QSslCertificate &cert, const QSslKey &privateKey)
 {
@@ -113,10 +116,11 @@ void IslInterface::initServer()
     socket->startServerEncryption();
     if (!socket->waitForEncrypted(5000)) {
         QList<QSslError> sslErrors(socket->sslHandshakeErrors());
-        if (sslErrors.isEmpty())
-            qDebug() << "[ISL] SSL handshake timeout, terminating connection";
-        else
-            qDebug() << "[ISL] SSL errors:" << sslErrors;
+        if (sslErrors.isEmpty()) {
+            qCDebug(IslInterfaceLog) << "SSL handshake timeout, terminating connection";
+        } else {
+            qCWarning(IslInterfaceLog) << "SSL errors:" << sslErrors;
+        }
         deleteLater();
         return;
     }
@@ -157,7 +161,7 @@ void IslInterface::initServer()
 
     server->islLock.lockForWrite();
     if (server->islConnectionExists(serverId)) {
-        qDebug() << "[ISL] Duplicate connection to #" << serverId << "terminating connection";
+        qCDebug(IslInterfaceLog) << "Duplicate connection to #" << serverId << "terminating connection";
         deleteLater();
     } else {
         transmitMessage(message);
@@ -180,27 +184,28 @@ void IslInterface::initClient()
     expectedErrors.append(QSslError(QSslError::SelfSignedCertificate, peerCert));
     socket->ignoreSslErrors(expectedErrors);
 
-    qDebug() << "[ISL] Connecting to #" << serverId << ":" << peerAddress << ":" << peerPort;
+    qCDebug(IslInterfaceLog) << "Connecting to #" << serverId << ":" << peerAddress << ":" << peerPort;
 
     socket->connectToHostEncrypted(peerAddress, peerPort, peerHostName);
     if (!socket->waitForConnected(5000)) {
-        qDebug() << "[ISL] Socket error:" << socket->errorString();
+        qCDebug(IslInterfaceLog) << "Socket error:" << socket->errorString();
         deleteLater();
         return;
     }
     if (!socket->waitForEncrypted(5000)) {
         QList<QSslError> sslErrors(socket->sslHandshakeErrors());
-        if (sslErrors.isEmpty())
-            qDebug() << "[ISL] SSL handshake timeout, terminating connection";
-        else
-            qDebug() << "[ISL] SSL errors:" << sslErrors;
+        if (sslErrors.isEmpty()) {
+            qCDebug(IslInterfaceLog) << "SSL handshake timeout, terminating connection";
+        } else {
+            qCWarning(IslInterfaceLog) << "SSL errors:" << sslErrors;
+        }
         deleteLater();
         return;
     }
 
     server->islLock.lockForWrite();
     if (server->islConnectionExists(serverId)) {
-        qDebug() << "[ISL] Duplicate connection to #" << serverId << "terminating connection";
+        qCDebug(IslInterfaceLog) << "Duplicate connection to #" << serverId << "terminating connection";
         deleteLater();
         return;
     }
@@ -242,17 +247,21 @@ void IslInterface::readClient()
             return;
 
         IslMessage newMessage;
-        newMessage.ParseFromArray(inputBuffer.data(), messageLength);
+        bool ok = newMessage.ParseFromArray(inputBuffer.data(), messageLength);
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 
-        processMessage(newMessage);
+        if (ok) {
+            processMessage(newMessage);
+        } else {
+            qCWarning(IslInterfaceLog) << "parsing error!";
+        }
     } while (!inputBuffer.isEmpty());
 }
 
 void IslInterface::catchSocketError(QAbstractSocket::SocketError socketError)
 {
-    qDebug() << "[ISL] Socket error:" << socketError;
+    qCWarning(IslInterfaceLog) << "Socket error:" << socketError;
 
     server->islLock.lockForWrite();
     server->removeIslInterface(serverId);
@@ -270,7 +279,10 @@ void IslInterface::transmitMessage(const IslMessage &item)
     unsigned int size = static_cast<unsigned int>(item.ByteSize());
 #endif
     buf.resize(size + 4);
-    item.SerializeToArray(buf.data() + 4, size);
+    if (!item.SerializeToArray(buf.data() + 4, size)) {
+        qCWarning(IslInterfaceLog) << "transmit error!";
+        return;
+    }
     buf.data()[3] = (unsigned char)size;
     buf.data()[2] = (unsigned char)(size >> 8);
     buf.data()[1] = (unsigned char)(size >> 16);
@@ -368,7 +380,7 @@ void IslInterface::processSessionEvent(const SessionEvent &event, qint64 session
             QReadLocker clientsLocker(&server->clientsLock);
             Server_AbstractUserInterface *client = server->getUsersBySessionId().value(sessionId);
             if (!client) {
-                qDebug() << "IslInterface::processSessionEvent: session id" << sessionId << "not found";
+                qCDebug(IslInterfaceLog) << "IslInterface::processSessionEvent: session id" << sessionId << "not found";
                 break;
             }
             const Event_GameJoined &gameJoined = event.GetExtension(Event_GameJoined::ext);
@@ -382,7 +394,8 @@ void IslInterface::processSessionEvent(const SessionEvent &event, qint64 session
             QReadLocker clientsLocker(&server->clientsLock);
             Server_AbstractUserInterface *client = server->getUsersBySessionId().value(sessionId);
             if (!client) {
-                qDebug() << "IslInterface::processSessionEvent: session id" << sessionId << "not found";
+                qCWarning(IslInterfaceLog)
+                    << "IslInterface::processSessionEvent: session id" << sessionId << "not found";
                 break;
             }
 
@@ -430,7 +443,7 @@ void IslInterface::processRoomCommand(const CommandContainer &cont, qint64 sessi
 
 void IslInterface::processMessage(const IslMessage &item)
 {
-    qDebug() << getSafeDebugString(item);
+    qCDebug(IslInterfaceLog) << getSafeDebugString(item);
 
     switch (item.message_type()) {
         case IslMessage::ROOM_COMMAND_CONTAINER: {

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -7,11 +7,14 @@
 #include <QChar>
 #include <QDateTime>
 #include <QDebug>
+#include <QLoggingCategory>
 #include <QSqlError>
 #include <QSqlQuery>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/protocol/pb/game_replay.pb.h>
 #include <libcockatrice/utility/passwordhasher.h>
+
+inline Q_LOGGING_CATEGORY(DatabaseInterfaceLog, "database_interface");
 
 Servatrice_DatabaseInterface::Servatrice_DatabaseInterface(int _instanceId, Servatrice *_server)
     : instanceId(_instanceId), sqlDatabase(QSqlDatabase()), server(_server)
@@ -56,17 +59,16 @@ bool Servatrice_DatabaseInterface::openDatabase()
         sqlDatabase.close();
 
     const QString poolStr = instanceId == -1 ? QString("main") : QString("pool %1").arg(instanceId);
-    qDebug().noquote() << QString("[%1] Opening database...").arg(poolStr);
+    qCDebug(DatabaseInterfaceLog).noquote() << poolStr << "Opening database...";
     if (!sqlDatabase.open()) {
-        qCritical() << QString("[%1] Error opening database: %2").arg(poolStr).arg(sqlDatabase.lastError().text());
+        qCCritical(DatabaseInterfaceLog) << poolStr << "Error opening database:" << sqlDatabase.lastError().text();
         return false;
     }
 
     QSqlQuery *versionQuery = prepareQuery("select version from {prefix}_schema_version limit 1");
     if (!execSqlQuery(versionQuery)) {
-        qCritical() << QString("[%1] Error opening database: unable to load database schema version (hint: ensure the "
-                               "cockatrice_schema_version exists)")
-                           .arg(poolStr);
+        qCCritical(DatabaseInterfaceLog) << poolStr << "Error opening database: unable to load database schema version"
+                                         << "(hint: ensure the cockatrice_schema_version exists)";
         return false;
     }
 
@@ -74,24 +76,21 @@ bool Servatrice_DatabaseInterface::openDatabase()
         const int dbversion = versionQuery->value(0).toInt();
         const int expectedversion = DATABASE_SCHEMA_VERSION;
         if (dbversion < expectedversion) {
-            qCritical() << QString("[%1] Error opening database: the database schema version is too old, you need to "
-                                   "run the migrations to update it from version %2 to version %3")
-                               .arg(poolStr)
-                               .arg(dbversion)
-                               .arg(expectedversion);
+            qCCritical(DatabaseInterfaceLog) << poolStr
+                                             << "Error opening database: the database schema version is too old, you "
+                                                "need to run the migrations to update it from version"
+                                             << dbversion << "to version" << expectedversion;
             return false;
         } else if (dbversion > expectedversion) {
-            qCritical() << QString("[%1] Error opening database: the database schema version %2 is too new, you need "
-                                   "to update servatrice (this servatrice actually uses version %3)")
-                               .arg(poolStr)
-                               .arg(dbversion)
-                               .arg(expectedversion);
+            qCCritical(DatabaseInterfaceLog) << poolStr << "Error opening database: the database schema version"
+                                             << dbversion << "is too new, you need to update servatrice"
+                                             << "(this servatrice actually uses version" << expectedversion << ")";
             return false;
         }
     } else {
-        qCritical() << QString("[%1] Error opening database: unable to load database schema version (hint: ensure the "
-                               "cockatrice_schema_version contains a single record)")
-                           .arg(poolStr);
+        qCCritical(DatabaseInterfaceLog) << poolStr
+                                         << "Error opening database: unable to load database schema version (hint: "
+                                            "ensure the cockatrice_schema_version contains a single record)";
         return false;
     }
 
@@ -114,9 +113,7 @@ bool Servatrice_DatabaseInterface::checkSql()
 
     if (query.lastError().isValid()) {
         const auto &poolStr = instanceId == -1 ? QString("main") : QString("pool %1").arg(instanceId);
-        qCritical() << QString("[%1] Error executing query: %2, resetting connection")
-                           .arg(poolStr)
-                           .arg(query.lastError().text());
+        qCCritical(DatabaseInterfaceLog) << poolStr << "Error executing query:" << query.lastError().text();
 
         sqlDatabase.close();
         return openDatabase();
@@ -145,7 +142,7 @@ bool Servatrice_DatabaseInterface::execSqlQuery(QSqlQuery *query)
     if (query->exec())
         return true;
     const QString poolStr = instanceId == -1 ? QString("main") : QString("pool %1").arg(instanceId);
-    qCritical() << QString("[%1] Error executing query: %2").arg(poolStr).arg(query->lastError().text());
+    qCCritical(DatabaseInterfaceLog) << poolStr << "Error executing query:" << query->lastError().text();
     sqlDatabase.close();
     openDatabase();
     return false;
@@ -252,7 +249,8 @@ bool Servatrice_DatabaseInterface::registerUser(const QString &userName,
     query->bindValue(":token", token);
 
     if (!execSqlQuery(query)) {
-        qDebug() << "Failed to insert user: " << query->lastError() << " sql: " << query->lastQuery();
+        qCWarning(DatabaseInterfaceLog) << "Failed to insert user: " << query->lastError()
+                                        << " sql: " << query->lastQuery();
         return false;
     }
 
@@ -270,8 +268,8 @@ bool Servatrice_DatabaseInterface::activateUser(const QString &userName, const Q
     activateQuery->bindValue(":username", userName);
     activateQuery->bindValue(":token", token);
     if (!execSqlQuery(activateQuery)) {
-        qDebug() << "Account activation failed: SQL error." << activateQuery->lastError()
-                 << " sql: " << activateQuery->lastQuery();
+        qCWarning(DatabaseInterfaceLog) << "Account activation failed: SQL error." << activateQuery->lastError()
+                                        << " sql: " << activateQuery->lastQuery();
         return false;
     }
 
@@ -284,7 +282,8 @@ bool Servatrice_DatabaseInterface::activateUser(const QString &userName, const Q
             query->bindValue(":userName", userName);
 
             if (!execSqlQuery(query)) {
-                qDebug() << "Failed to activate user: " << query->lastError() << " sql: " << query->lastQuery();
+                qCWarning(DatabaseInterfaceLog)
+                    << "Failed to activate user: " << query->lastError() << " sql: " << query->lastQuery();
                 return false;
             }
 
@@ -326,7 +325,7 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
                 prepareQuery("select password_sha512, active from {prefix}_users where name = :name");
             passwordQuery->bindValue(":name", user);
             if (!execSqlQuery(passwordQuery)) {
-                qDebug("Login denied: SQL error");
+                qCWarning(DatabaseInterfaceLog) << "Login denied: SQL error";
                 return NotLoggedIn;
             }
 
@@ -334,7 +333,7 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
                 const QString correctPasswordSha512 = passwordQuery->value(0).toString();
                 const bool userIsActive = passwordQuery->value(1).toBool();
                 if (!userIsActive) {
-                    qDebug("Login denied: user not active");
+                    qCWarning(DatabaseInterfaceLog) << "Login denied: user not active";
                     return UserIsInactive;
                 }
                 QString hashedPassword;
@@ -344,14 +343,14 @@ AuthenticationResult Servatrice_DatabaseInterface::checkUserPassword(Server_Prot
                     hashedPassword = password;
                 }
                 if (correctPasswordSha512 == hashedPassword) {
-                    qDebug("Login accepted: password right");
+                    qCDebug(DatabaseInterfaceLog) << "Login accepted: password right";
                     return PasswordRight;
                 } else {
-                    qDebug("Login denied: password wrong");
+                    qCDebug(DatabaseInterfaceLog) << "Login denied: password wrong";
                     return NotLoggedIn;
                 }
             } else {
-                qDebug("Login accepted: unknown user");
+                qCDebug(DatabaseInterfaceLog) << "Login accepted: unknown user";
                 return UnknownUser;
             }
         }
@@ -369,7 +368,7 @@ bool Servatrice_DatabaseInterface::checkUserIsBanned(const QString &ipAddress,
         return false;
 
     if (!checkSql()) {
-        qDebug("Failed to check if user is banned. Database invalid.");
+        qCWarning(DatabaseInterfaceLog) << "Failed to check if user is banned. Database invalid.";
         return false;
     }
 
@@ -400,7 +399,7 @@ bool Servatrice_DatabaseInterface::checkUserIsIdBanned(const QString &clientId,
     idBanQuery->bindValue(":id", clientId);
     idBanQuery->bindValue(":id2", clientId);
     if (!execSqlQuery(idBanQuery)) {
-        qDebug() << "Id ban check failed: SQL error." << idBanQuery->lastError();
+        qCWarning(DatabaseInterfaceLog) << "Id ban check failed: SQL error." << idBanQuery->lastError();
         return false;
     }
 
@@ -410,7 +409,7 @@ bool Servatrice_DatabaseInterface::checkUserIsIdBanned(const QString &clientId,
         if ((secondsLeft > 0) || permanentBan) {
             banReason = idBanQuery->value(2).toString();
             banSecondsRemaining = permanentBan ? 0 : secondsLeft;
-            qDebug() << "User is banned by client id" << clientId;
+            qCDebug(DatabaseInterfaceLog) << "User is banned by client id" << clientId;
             return true;
         }
     }
@@ -428,7 +427,7 @@ bool Servatrice_DatabaseInterface::checkUserIsNameBanned(const QString &userName
     nameBanQuery->bindValue(":name1", userName);
     nameBanQuery->bindValue(":name2", userName);
     if (!execSqlQuery(nameBanQuery)) {
-        qDebug() << "Name ban check failed: SQL error" << nameBanQuery->lastError();
+        qCWarning(DatabaseInterfaceLog) << "Name ban check failed: SQL error" << nameBanQuery->lastError();
         return false;
     }
 
@@ -438,7 +437,7 @@ bool Servatrice_DatabaseInterface::checkUserIsNameBanned(const QString &userName
         if ((secondsLeft > 0) || permanentBan) {
             banReason = nameBanQuery->value(2).toString();
             banSecondsRemaining = permanentBan ? 0 : secondsLeft;
-            qDebug() << "Username" << userName << "is banned by name";
+            qCDebug(DatabaseInterfaceLog) << "Username" << userName << "is banned by name";
             return true;
         }
     }
@@ -464,7 +463,7 @@ bool Servatrice_DatabaseInterface::checkUserIsIpBanned(const QString &ipAddress,
     ipBanQuery->bindValue(":address", ipAddress);
     ipBanQuery->bindValue(":address2", ipAddress);
     if (!execSqlQuery(ipBanQuery)) {
-        qDebug() << "IP ban check failed: SQL error." << ipBanQuery->lastError();
+        qCWarning(DatabaseInterfaceLog) << "IP ban check failed: SQL error." << ipBanQuery->lastError();
         return false;
     }
 
@@ -474,7 +473,7 @@ bool Servatrice_DatabaseInterface::checkUserIsIpBanned(const QString &ipAddress,
         if ((secondsLeft > 0) || permanentBan) {
             banReason = ipBanQuery->value(2).toString();
             banSecondsRemaining = permanentBan ? 0 : secondsLeft;
-            qDebug() << "User is banned by address" << ipAddress;
+            qCDebug(DatabaseInterfaceLog) << "User is banned by address" << ipAddress;
             return true;
         }
     }
@@ -865,12 +864,17 @@ void Servatrice_DatabaseInterface::storeGameInformation(const QString &roomName,
         const unsigned int size = static_cast<unsigned int>(replayList[i]->ByteSize());
 #endif
         blob.resize(size);
-        replayList[i]->SerializeToArray(blob.data(), size);
+        qulonglong replayId = replayList[i]->replay_id();
+        if (replayList[i]->SerializeToArray(blob.data(), size)) {
 
-        replayIds.append(QVariant((qulonglong)replayList[i]->replay_id()));
-        replayGameIds.append(gameInfo.game_id());
-        replayDurations.append(replayList[i]->duration_seconds());
-        replayBlobs.append(blob);
+            replayIds.append(QVariant(replayId));
+            replayGameIds.append(gameInfo.game_id());
+            replayDurations.append(replayList[i]->duration_seconds());
+            replayBlobs.append(blob);
+        } else {
+            qCWarning(DatabaseInterfaceLog)
+                << "failed to serialise replay, id:" << replayId << "game:" << gameInfo.game_id();
+        }
     }
 
     {
@@ -1017,7 +1021,7 @@ bool Servatrice_DatabaseInterface::changeUserPassword(const QString &user,
     passwordQuery->bindValue(":name", user);
 
     if (!execSqlQuery(passwordQuery)) {
-        qDebug("Change password denied: SQL error");
+        qCWarning(DatabaseInterfaceLog) << "Change password denied: SQL error";
         return false;
     }
 
@@ -1084,7 +1088,7 @@ void Servatrice_DatabaseInterface::updateUsersLastLoginData(const QString &userN
     QSqlQuery *query = prepareQuery("select id from {prefix}_users where name = :user_name");
     query->bindValue(":user_name", userName);
     if (!execSqlQuery(query)) {
-        qDebug("Failed to locate user id when updating users last login data: SQL Error");
+        qCWarning(DatabaseInterfaceLog) << "Failed to locate user id when updating users last login data: SQL Error";
         return;
     }
 
@@ -1133,7 +1137,7 @@ QList<ServerInfo_Ban> Servatrice_DatabaseInterface::getUserBanHistory(const QStr
     query->bindValue(":user_name", userName);
 
     if (!execSqlQuery(query)) {
-        qDebug("Failed to collect ban history information: SQL Error");
+        qCWarning(DatabaseInterfaceLog) << "Failed to collect ban history information: SQL Error";
         return results;
     }
 
@@ -1168,7 +1172,7 @@ bool Servatrice_DatabaseInterface::addWarning(const QString userName,
     query->bindValue(":warn_reason", warningReason);
     query->bindValue(":client_id", clientID);
     if (!execSqlQuery(query)) {
-        qDebug("Failed to collect create warning history information: SQL Error");
+        qCWarning(DatabaseInterfaceLog) << "Failed to collect create warning history information: SQL Error";
         return false;
     }
 
@@ -1189,7 +1193,7 @@ QList<ServerInfo_Warning> Servatrice_DatabaseInterface::getUserWarnHistory(const
     query->bindValue(":user_id", userID);
 
     if (!execSqlQuery(query)) {
-        qDebug("Failed to collect warning history information: SQL Error");
+        qCWarning(DatabaseInterfaceLog) << "Failed to collect warning history information: SQL Error";
         return results;
     }
 
@@ -1296,7 +1300,7 @@ QList<ServerInfo_ChatMessage> Servatrice_DatabaseInterface::getMessageLogHistory
     }
 
     if (!execSqlQuery(query)) {
-        qDebug("Failed to collect log history information: SQL Error");
+        qCWarning(DatabaseInterfaceLog) << "Failed to collect log history information: SQL Error";
         return results;
     }
 
@@ -1324,7 +1328,8 @@ int Servatrice_DatabaseInterface::checkNumberOfUserAccounts(const QString &email
     query->bindValue(":user_email", email);
 
     if (!execSqlQuery(query)) {
-        qDebug("Failed to identify the number of users accounts for users email address: SQL Error");
+        qCWarning(DatabaseInterfaceLog)
+            << "Failed to identify the number of users accounts for users email address: SQL Error";
         return 0;
     }
 

--- a/servatrice/src/serversocketinterface.cpp
+++ b/servatrice/src/serversocketinterface.cpp
@@ -31,6 +31,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QHostAddress>
+#include <QLoggingCategory>
 #include <QRegularExpression>
 #include <QSqlError>
 #include <QSqlQuery>
@@ -83,6 +84,10 @@
 #include <server_room.h>
 #include <string>
 
+inline Q_LOGGING_CATEGORY(AbstractServerSocketInterfaceLog, "abstract_server_socket_interface");
+inline Q_LOGGING_CATEGORY(TcpServerSocketInterfaceLog, "tcp_server_socket_interface");
+inline Q_LOGGING_CATEGORY(WebsocketServerSocketInterfaceLog, "websocket_server_socket_interface");
+
 static const int protocolVersion = 14;
 
 AbstractServerSocketInterface::AbstractServerSocketInterface(Servatrice *_server,
@@ -130,7 +135,7 @@ bool AbstractServerSocketInterface::initSession()
 
 void AbstractServerSocketInterface::catchSocketError(QAbstractSocket::SocketError socketError)
 {
-    qDebug() << "Socket error:" << socketError;
+    qCWarning(AbstractServerSocketInterfaceLog) << "Socket error:" << socketError;
 
     prepareDestroy();
 }
@@ -1100,7 +1105,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdBanFromServer(const Com
         clientIdQuery->bindValue(":client_id", nameFromStdString(cmd.clientid()));
         sqlInterface->execSqlQuery(clientIdQuery);
         if (!sqlInterface->execSqlQuery(clientIdQuery)) {
-            qDebug("ClientID username ban lookup failed: SQL Error");
+            qCWarning(AbstractServerSocketInterfaceLog) << "ClientID username ban lookup failed: SQL Error";
         } else {
             while (clientIdQuery->next()) {
                 userName = clientIdQuery->value(0).toString();
@@ -1152,7 +1157,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
 {
     QString userName = nameFromStdString(cmd.user_name());
     QString clientId = nameFromStdString(cmd.clientid());
-    qDebug() << "Got register command for user:" << userName;
+    qCDebug(AbstractServerSocketInterfaceLog) << "Got register command for user:" << userName;
 
     bool registrationEnabled = settingsCache->value("registration/enabled", false).toBool();
     if (!registrationEnabled) {
@@ -1289,7 +1294,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdRegisterAccount(const C
                                                    country, !requireEmailActivation);
 
     if (regSucceeded) {
-        qDebug() << "Accepted register command for user:" << userName;
+        qCDebug(AbstractServerSocketInterfaceLog) << "Accepted register command for user:" << userName;
         if (requireEmailActivation) {
             QSqlQuery *query =
                 sqlInterface->prepareQuery("insert into {prefix}_activation_emails (name) values(:name)");
@@ -1337,7 +1342,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdActivateAccount(const C
         clientId = "UNKNOWN";
 
     if (sqlInterface->activateUser(userName, token)) {
-        qDebug() << "Accepted activation for user" << userName;
+        qCDebug(AbstractServerSocketInterfaceLog) << "Accepted activation for user" << userName;
 
         if (servatrice->getEnableRegistrationAudit())
             sqlInterface->addAuditRecord(userName.simplified(), this->getAddress(), clientId.simplified(),
@@ -1345,7 +1350,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdActivateAccount(const C
 
         return Response::RespActivationAccepted;
     } else {
-        qDebug() << "Failed activation for user" << userName;
+        qCDebug(AbstractServerSocketInterfaceLog) << "Failed activation for user" << userName;
 
         if (servatrice->getEnableRegistrationAudit())
             sqlInterface->addAuditRecord(userName.simplified(), this->getAddress(), clientId.simplified(),
@@ -1493,7 +1498,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForgotPasswordRequest(c
     const QString userName = nameFromStdString(cmd.user_name());
     const QString clientId = nameFromStdString(cmd.clientid());
 
-    qDebug() << "Received reset password request from user:" << userName;
+    qCDebug(AbstractServerSocketInterfaceLog) << "Received reset password request from user:" << userName;
 
     if (!servatrice->getEnableForgotPassword()) {
         if (servatrice->getEnableForgotPasswordAudit())
@@ -1575,7 +1580,7 @@ Response::ResponseCode AbstractServerSocketInterface::cmdForgotPasswordReset(con
     Q_UNUSED(rc);
     QString userName = nameFromStdString(cmd.user_name());
     QString clientId = nameFromStdString(cmd.clientid());
-    qDebug() << "Received reset password reset from user:" << userName;
+    qCDebug(AbstractServerSocketInterfaceLog) << "Received reset password reset from user:" << userName;
 
     if (!sqlInterface->doesForgotPasswordExist(userName)) {
         if (servatrice->getEnableForgotPasswordAudit())
@@ -1626,7 +1631,7 @@ AbstractServerSocketInterface::cmdForgotPasswordChallenge(const Command_ForgotPa
     const QString userName = nameFromStdString(cmd.user_name());
     const QString clientId = nameFromStdString(cmd.clientid());
 
-    qDebug() << "Received reset password challenge from user:" << userName;
+    qCDebug(AbstractServerSocketInterfaceLog) << "Received reset password challenge from user:" << userName;
 
     if (!servatrice->getEnableForgotPasswordChallenge()) {
         if (servatrice->getEnableForgotPasswordAudit()) {
@@ -1971,13 +1976,16 @@ void TcpServerSocketInterface::flushOutputQueue()
         unsigned int size = static_cast<unsigned int>(item.ByteSize());
 #endif
         buf.resize(size + 4);
-        item.SerializeToArray(buf.data() + 4, size);
-        buf.data()[3] = (unsigned char)size;
-        buf.data()[2] = (unsigned char)(size >> 8);
-        buf.data()[1] = (unsigned char)(size >> 16);
-        buf.data()[0] = (unsigned char)(size >> 24);
-        // In case socket->write() calls catchSocketError(), the mutex must not be locked during this call.
-        writeToSocket(buf);
+        if (item.SerializeToArray(buf.data() + 4, size)) {
+            buf.data()[3] = (unsigned char)size;
+            buf.data()[2] = (unsigned char)(size >> 8);
+            buf.data()[1] = (unsigned char)(size >> 16);
+            buf.data()[0] = (unsigned char)(size >> 24);
+            // In case socket->write() calls catchSocketError(), the mutex must not be locked during this call.
+            writeToSocket(buf);
+        } else {
+            qCWarning(TcpServerSocketInterfaceLog) << "serialisation error!";
+        }
 
         totalBytes += size + 4;
         locker.relock();
@@ -2010,41 +2018,48 @@ void TcpServerSocketInterface::readClient()
             return;
 
         CommandContainer newCommandContainer;
+        bool ok;
         try {
-            newCommandContainer.ParseFromArray(inputBuffer.data(), messageLength);
+            ok = newCommandContainer.ParseFromArray(inputBuffer.data(), messageLength);
         } catch (std::exception &e) {
-            qDebug() << "Caught std::exception in" << __FILE__ << __LINE__ <<
+            qCWarning(TcpServerSocketInterfaceLog) << "Caught std::exception in" << __FILE__ << __LINE__ <<
 #ifdef _MSC_VER // Visual Studio
-                __FUNCTION__;
+                __FUNCTION__
 #else
-                __PRETTY_FUNCTION__;
+                __PRETTY_FUNCTION__
 #endif
-            qDebug() << "Exception:" << e.what();
-            qDebug() << "Message coming from:" << getAddress();
-            qDebug() << "Message length:" << messageLength;
-            qDebug() << "Message content:" << inputBuffer.toHex();
+                                                   << Qt::endl
+                                                   << "Exception:" << e.what() << Qt::endl
+                                                   << "Message coming from:" << getAddress() << Qt::endl
+                                                   << "Message length:" << messageLength << Qt::endl
+                                                   << "Message content:" << inputBuffer.toHex();
         } catch (...) {
-            qDebug() << "Unhandled exception in" << __FILE__ << __LINE__ <<
+            qCWarning(TcpServerSocketInterfaceLog) << "Unhandled exception in" << __FILE__ << __LINE__ <<
 #ifdef _MSC_VER // Visual Studio
-                __FUNCTION__;
+                __FUNCTION__
 #else
-                __PRETTY_FUNCTION__;
+                __PRETTY_FUNCTION__
 #endif
-            qDebug() << "Message coming from:" << getAddress();
+                                                   << Qt::endl
+                                                   << "Message coming from:" << getAddress();
         }
-
         inputBuffer.remove(0, messageLength);
         messageInProgress = false;
 
-        // dirty hack to make v13 client display the correct error message
-        if (handshakeStarted)
-            processCommandContainer(newCommandContainer);
-        else if (!newCommandContainer.has_cmd_id()) {
-            handshakeStarted = true;
-            if (!initTcpSession())
-                prepareDestroy();
+        if (ok) {
+            // dirty hack to make v13 client display the correct error message
+            if (handshakeStarted)
+                processCommandContainer(newCommandContainer);
+            else if (!newCommandContainer.has_cmd_id()) {
+                handshakeStarted = true;
+                if (!initTcpSession())
+                    prepareDestroy();
+            }
+            // end of hack
+        } else {
+            qCWarning(TcpServerSocketInterfaceLog) << "parsing error!";
         }
-        // end of hack
+
     } while (!inputBuffer.isEmpty());
 }
 
@@ -2172,9 +2187,12 @@ void WebsocketServerSocketInterface::flushOutputQueue()
         unsigned int size = static_cast<unsigned int>(item.ByteSize());
 #endif
         buf.resize(size);
-        item.SerializeToArray(buf.data(), size);
-        // In case socket->write() calls catchSocketError(), the mutex must not be locked during this call.
-        writeToSocket(buf);
+        if (item.SerializeToArray(buf.data(), size)) {
+            // In case socket->write() calls catchSocketError(), the mutex must not be locked during this call.
+            writeToSocket(buf);
+        } else {
+            qCWarning(TcpServerSocketInterfaceLog) << "serialisation error!";
+        }
 
         totalBytes += size;
         locker.relock();
@@ -2190,30 +2208,37 @@ void WebsocketServerSocketInterface::binaryMessageReceived(const QByteArray &mes
     servatrice->incRxBytes(message.size());
 
     CommandContainer newCommandContainer;
+    bool ok;
     try {
-        newCommandContainer.ParseFromArray(message.data(), message.size());
+        ok = newCommandContainer.ParseFromArray(message.data(), message.size());
     } catch (std::exception &e) {
-        qDebug() << "Caught std::exception in" << __FILE__ << __LINE__ <<
+        qCWarning(WebsocketServerSocketInterfaceLog) << "Caught std::exception in" << __FILE__ << __LINE__ <<
 #ifdef _MSC_VER // Visual Studio
-            __FUNCTION__;
+            __FUNCTION__
 #else
-            __PRETTY_FUNCTION__;
+            __PRETTY_FUNCTION__
 #endif
-        qDebug() << "Exception:" << e.what();
-        qDebug() << "Message coming from:" << getAddress();
-        qDebug() << "Message length:" << message.size();
-        qDebug() << "Message content:" << message.toHex();
+                                                     << Qt::endl
+                                                     << "Exception:" << e.what() << Qt::endl
+                                                     << "Message coming from:" << getAddress() << Qt::endl
+                                                     << "Message length:" << message.size() << Qt::endl
+                                                     << "Message content:" << message.toHex();
     } catch (...) {
-        qDebug() << "Unhandled exception in" << __FILE__ << __LINE__ <<
+        qCWarning(WebsocketServerSocketInterfaceLog) << "Unhandled exception in" << __FILE__ << __LINE__ <<
 #ifdef _MSC_VER // Visual Studio
-            __FUNCTION__;
+            __FUNCTION__
 #else
-            __PRETTY_FUNCTION__;
+            __PRETTY_FUNCTION__
 #endif
-        qDebug() << "Message coming from:" << getAddress();
+                                                     << Qt::endl
+                                                     << "Message coming from:" << getAddress();
     }
 
-    processCommandContainer(newCommandContainer);
+    if (ok) {
+        processCommandContainer(newCommandContainer);
+    } else {
+        qCWarning(WebsocketServerSocketInterfaceLog) << "parsing error!";
+    }
 }
 
 bool AbstractServerSocketInterface::isPasswordLongEnough(const int passwordLength)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #IssueNumber

## Short roundup of the initial problem
Player counters support expressions when setting theirs values but card counters currently do not.

## What will change with this Pull Request?
- support expressions when setting card counters
- reuse `AbstractCounterDialog` based on https://github.com/brunoalr/Cockatrice/blob/c5fde071e79c162fa20a74d133b97c9488a4cb95/cockatrice/src/game/board/abstract_counter.cpp#L180

## Screenshots
<!-- simply drag & drop image files directly into this description! -->

https://github.com/user-attachments/assets/92626326-11f7-4349-b1dd-d5059033cf84

